### PR TITLE
AB#238930

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>2.34.0</version>
+            <version>2.46.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.3</version>
+            <version>1.11.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,22 @@
         <url>http://github.com/optimove/Optimove-SDK-Engagement-java/tree/master</url>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>26.52.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>2.46.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/readme.md
+++ b/readme.md
@@ -46,10 +46,10 @@ public class Main {
         Metadata metadata = engagement.getMetadata();
         System.out.println(metadata.getNumberOfBatches());
 
-        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfBatches(); fileNumber++) {
-            System.out.println("file number: " + fileNumber);
+        for (int batchNumber = 1; batchNumber <= metadata.getNumberOfBatches(); batchNumber++) {
+            System.out.println("batch number: " + batchNumber);
 
-            try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(fileNumber)) {
+            try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(batchNumber)) {
                 GenericRecord record = null;
                 while (dataFileReader.hasNext()) {
                     record = dataFileReader.next(record);
@@ -86,27 +86,27 @@ logger.error("Failed to retrieve metadata: " + e.getMessage(), e);
 }
 ```
 ### Customer Data Retrieval
-When retrieving customer data for an engagement, the SDK may encounter errors such as a missing or malformed customer data file, or an invalid file ID.
+When retrieving customer data for an engagement, the SDK may encounter errors such as a missing or malformed customer data file, or an invalid batch ID.
 
 In the case of a missing or malformed customer data file, the getCustomerBatchById() method will throw a RuntimeException with a message indicating the cause of the error. For example:
 
 
 ```java
-try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(fileNumber)) {
+try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(batchNumber)) {
 // use dataFileReader
 } catch (RuntimeException e) {
 logger.error("Failed to get customer batch by id: " + e.getMessage(), e);
 // handle error
 }
 ```
-If an invalid file ID is provided, the getCustomerBatchById() method will throw an IllegalArgumentException with a message indicating the cause of the error. For example:
+If an invalid batch ID is provided, the getCustomerBatchById() method will throw an IllegalArgumentException with a message indicating the cause of the error. For example:
 
 
 ```java
 try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(-1)) {
 // use dataFileReader
 } catch (IllegalArgumentException e) {
-logger.error("Invalid file id: " + e.getMessage(), e);
+logger.error("Invalid batch id: " + e.getMessage(), e);
 // handle error
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -41,12 +41,12 @@ public class Main {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(Main.class);
 
-        Engagement engagement = new Engagement(null, 1, "bucket-name", "customers-folder/customers", "metadata-path/metadata_287934", logger);
+        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 1111,\r\n  \"EngagementID\": 1111,\r\n  \"TenantID\": 1111,\r\n  \"BucketName\": \"bucketName\",\r\n  \"CustomersFolderPath\": \"path\",\r\n  \"MetadataFilePath\": \"pathCustomers\",\r\n  \"DecryptionKey\": \"some-secret-key\",\r\n  \"ChannelID\": 1111\r\n}", logger);
 
         Metadata metadata = engagement.getMetadata();
-        System.out.println(metadata.getNumberOfFiles());
+        System.out.println(metadata.getNumberOfBatches());
 
-        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfFiles(); fileNumber++) {
+        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfBatches(); fileNumber++) {
             System.out.println("file number: " + fileNumber);
 
             try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(fileNumber)) {

--- a/src/main/java/optimove/sdk/engagement/Engagement.java
+++ b/src/main/java/optimove/sdk/engagement/Engagement.java
@@ -75,7 +75,7 @@ public class Engagement {
 
     public Metadata getMetadata() {
         try {
-            Blob fileBlob = StorageSingleton.getBlob(this.settings.getBucketName(), this.settings.getMetadataFilePath());
+            Blob fileBlob = StorageSingleton.getBlob(this.settings.getBucketName(), this.settings.getMetadataFilePath(), this.settings.getDecryptionKey());
             String metadataString = StorageSingleton.blobToString(fileBlob, this.settings.getDecryptionKey());
 
             return MetadataService.jsonStringToMetadata(metadataString);

--- a/src/main/java/optimove/sdk/engagement/EngagementConfig.java
+++ b/src/main/java/optimove/sdk/engagement/EngagementConfig.java
@@ -1,0 +1,49 @@
+package optimove.sdk.engagement;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class EngagementConfig {
+    @JsonProperty("DecryptionKey")
+    private String decryptionKey;
+
+    @JsonProperty("TenantID")
+    private int tenantID;
+
+    @JsonProperty("BucketName")
+    private String bucketName;
+
+    @JsonProperty("CustomersFolderPath")
+    private String customersFolderPath;
+
+    @JsonProperty("MetadataFilePath")
+    private String metadataFilePath;
+
+    @JsonProperty("EventTypeID")
+    private int eventTypeId;
+
+    @JsonProperty("TimeStamp")
+    private String timestamp;
+
+    @JsonProperty("CampaignID")
+    private int campaignId;
+
+    @JsonProperty("EngagementID")
+    private int engagementId;
+
+    @JsonProperty("ChannelID")
+    private int channelId;
+
+    // Getters
+    public String getDecryptionKey() { return decryptionKey; }
+    public int getTenantID() { return tenantID; }
+    public String getBucketName() { return bucketName; }
+    public String getCustomersFolderPath() { return customersFolderPath; }
+    public String getMetadataFilePath() { return metadataFilePath; }
+    public int getEventTypeId() { return eventTypeId; }
+    public String getTimestamp() { return timestamp; }
+    public int getCampaignId() { return campaignId; }
+    public int getEngagementId() { return engagementId; }
+    public int getChannelId() { return channelId; }
+}

--- a/src/main/java/optimove/sdk/engagement/Metadata.java
+++ b/src/main/java/optimove/sdk/engagement/Metadata.java
@@ -88,7 +88,7 @@ public class Metadata {
         return NumberOfCustomers;
     }
 
-    public long getNumberOfFiles() {
+    public long getNumberOfBatches() {
         return NumberOfFiles;
     }
 

--- a/src/main/java/optimove/sdk/engagement/Metadata.java
+++ b/src/main/java/optimove/sdk/engagement/Metadata.java
@@ -88,6 +88,10 @@ public class Metadata {
         return NumberOfCustomers;
     }
 
+    public long getNumberOfFiles() {
+        return NumberOfFiles;
+    }
+
     public long getNumberOfBatches() {
         return NumberOfFiles;
     }

--- a/src/main/java/optimove/sdk/engagement/StorageSingleton.java
+++ b/src/main/java/optimove/sdk/engagement/StorageSingleton.java
@@ -12,14 +12,12 @@ import java.nio.charset.StandardCharsets;
 public class StorageSingleton {
 
     private static Storage instance = null;
-    private static final String projectId = "optimoveSDK";
 
     private StorageSingleton() { }
 
     public static Storage getInstance() {
         if(instance == null) {
             instance = StorageOptions.newBuilder()
-                    .setProjectId(projectId)
                     .build()
                     .getService();
         }

--- a/src/main/java/optimove/sdk/engagement/StorageSingleton.java
+++ b/src/main/java/optimove/sdk/engagement/StorageSingleton.java
@@ -23,9 +23,11 @@ public class StorageSingleton {
         }
         return instance;
     }
-
     public static Blob getBlob(String bucketName, String srcFileName) {
-        return getInstance().get(bucketName, srcFileName);
+        return getInstance().get(BlobId.of(bucketName, srcFileName));
+    }
+    public static Blob getBlob(String bucketName, String srcFileName, String decryptionKey) {
+        return getInstance().get(BlobId.of(bucketName, srcFileName), Storage.BlobGetOption.decryptionKey(decryptionKey));
     }
     public static ReadChannel getReadChanel(String bucketName, String srcFileName) {
         return getInstance().reader(BlobId.of(bucketName, srcFileName));

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -17,17 +17,17 @@ public class Main {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(Main.class);
 
-        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 8677,\r\n  \"EngagementID\": 9061,\r\n  \"TenantID\": 593,\r\n  \"BucketName\": \"optigration-external-eu\",\r\n  \"CustomersFolderPath\": \"593_2025-01-08 09 00_optigration demo_507_9061/customers\",\r\n  \"MetadataFilePath\": \"593_2025-01-08 09 00_optigration demo_507_9061/metadata_9061\",\r\n  \"DecryptionKey\": \"Sdy+upo5M2yFYOWYqk3cxBoZHq2vDNaXRZeqxUSITIU=\",\r\n  \"ChannelID\": 507\r\n}", logger);
+        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 1111,\r\n  \"EngagementID\": 1111,\r\n  \"TenantID\": 1111,\r\n  \"BucketName\": \"bucketName\",\r\n  \"CustomersFolderPath\": \"path\",\r\n  \"MetadataFilePath\": \"pathCustomers\",\r\n  \"DecryptionKey\": \"some-secret-key\",\r\n  \"ChannelID\": 1111\r\n}", logger);
 
         Metadata metadata = engagement.getMetadata();
         System.out.println(metadata.getNumberOfBatches());
 
-        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfBatches(); fileNumber++) {
-            System.out.println("file number: " + fileNumber);
+        for (int batchNumber = 1; batchNumber <= metadata.getNumberOfBatches(); batchNumber++) {
+            System.out.println("batch number: " + batchNumber);
 
             DataFileStream<GenericRecord> dataFileReader = null;
             try {
-                dataFileReader = engagement.getCustomerBatchById(fileNumber);
+                dataFileReader = engagement.getCustomerBatchById(batchNumber);
                 GenericRecord record = null;
                 while (dataFileReader.hasNext()) {
                     record = dataFileReader.next(record);

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -3,10 +3,13 @@ package org.example;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 
 import optimove.sdk.engagement.Engagement;
 import optimove.sdk.engagement.Metadata;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,15 +17,17 @@ public class Main {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(Main.class);
 
-        Engagement engagement = new Engagement(null, 1, "bucket-name", "customers-folder/customers", "metadata-path/metadata_287934", logger);
+        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 1111,\r\n  \"EngagementID\": 1111,\r\n  \"TenantID\": 1111,\r\n  \"BucketName\": \"bucketName\",\r\n  \"CustomersFolderPath\": \"path\",\r\n  \"MetadataFilePath\": \"pathCustomers\",\r\n  \"DecryptionKey\": \"some-secret-key\",\r\n  \"ChannelID\": 1111\r\n}", logger);
 
         Metadata metadata = engagement.getMetadata();
-        System.out.println(metadata.getNumberOfFiles());
+        System.out.println(metadata.getNumberOfBatches());
 
-        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfFiles(); fileNumber++) {
+        for (int fileNumber = 1; fileNumber <= metadata.getNumberOfBatches(); fileNumber++) {
             System.out.println("file number: " + fileNumber);
 
-            try (DataFileStream<GenericRecord> dataFileReader = engagement.getCustomerBatchById(fileNumber)) {
+            DataFileStream<GenericRecord> dataFileReader = null;
+            try {
+                dataFileReader = engagement.getCustomerBatchById(fileNumber);
                 GenericRecord record = null;
                 while (dataFileReader.hasNext()) {
                     record = dataFileReader.next(record);

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -17,7 +17,7 @@ public class Main {
     public static void main(String[] args) {
         Logger logger = LoggerFactory.getLogger(Main.class);
 
-        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 1111,\r\n  \"EngagementID\": 1111,\r\n  \"TenantID\": 1111,\r\n  \"BucketName\": \"bucketName\",\r\n  \"CustomersFolderPath\": \"path\",\r\n  \"MetadataFilePath\": \"pathCustomers\",\r\n  \"DecryptionKey\": \"some-secret-key\",\r\n  \"ChannelID\": 1111\r\n}", logger);
+        Engagement engagement = new Engagement("{\r\n  \"EventTypeID\": 14,\r\n  \"TimeStamp\": \"2025-01-08 08:58\",\r\n  \"CampaignID\": 8677,\r\n  \"EngagementID\": 9061,\r\n  \"TenantID\": 593,\r\n  \"BucketName\": \"optigration-external-eu\",\r\n  \"CustomersFolderPath\": \"593_2025-01-08 09 00_optigration demo_507_9061/customers\",\r\n  \"MetadataFilePath\": \"593_2025-01-08 09 00_optigration demo_507_9061/metadata_9061\",\r\n  \"DecryptionKey\": \"Sdy+upo5M2yFYOWYqk3cxBoZHq2vDNaXRZeqxUSITIU=\",\r\n  \"ChannelID\": 507\r\n}", logger);
 
         Metadata metadata = engagement.getMetadata();
         System.out.println(metadata.getNumberOfBatches());

--- a/src/test/java/EngagementTest.java
+++ b/src/test/java/EngagementTest.java
@@ -57,7 +57,7 @@ public class EngagementTest {
 
         try (MockedStatic<StorageSingleton> classMock = mockStatic(StorageSingleton.class)) {
 
-            classMock.when(() -> StorageSingleton.getBlob(anyString(), anyString())).thenReturn(fileBlob);
+            classMock.when(() -> StorageSingleton.getBlob(anyString(), anyString(), anyString())).thenReturn(fileBlob);
             classMock.when(() -> StorageSingleton.blobToString(eq(fileBlob), any(String.class))).thenReturn(metadataString);
             classMock.when(() -> StorageSingleton.getReadChanel(anyString(), anyString(), anyString())).thenReturn(readChannel);
 

--- a/src/test/java/EngagementTest.java
+++ b/src/test/java/EngagementTest.java
@@ -68,7 +68,7 @@ public class EngagementTest {
 
             // Verify the expected behavior
             assertNotNull(metadata);
-            assumeTrue(metadata.getNumberOfFiles() == 3);
+            assumeTrue(metadata.getNumberOfBatches() == 3);
             assumeTrue(metadata.getNumberOfCustomers() == 300);
             assumeTrue(metadata.getCampaignPlanID() == 10);
             assumeTrue(metadata.getCampaignID() == 1);


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
main_("main"):::modified
Engagement_Engagement_("Engagement.Engagement"):::added
Engagement_getMetadata_("Engagement.getMetadata"):::modified
StorageSingleton_getBlob_("StorageSingleton.getBlob"):::modified
StorageSingleton_getInstance_("StorageSingleton.getInstance"):::modified
getNumberOfBatches_("getNumberOfBatches"):::added
main_ -- "Replaced constructor with JSON config for flexible initialization" --> Engagement_Engagement_
main_ -- "Fetches metadata blob using decryption key for security" --> Engagement_getMetadata_
Engagement_getMetadata_ -- "Added decryption key parameter to securely fetch blob" --> StorageSingleton_getBlob_
StorageSingleton_getBlob_ -- "Removed project ID setting in storage instance creation" --> StorageSingleton_getInstance_
main_ -- "Renamed method to reflect batch processing semantics" --> getNumberOfBatches_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Introduce a new JSON-based configuration mechanism for the <code>Engagement</code> SDK, allowing for more flexible initialization of the <code>Engagement</code> component by parsing configuration details from a JSON string or object. Integrate the decryption key directly into Google Cloud Storage blob retrieval operations, enhancing secure data access, and update internal terminology from "files" to "batches" for clarity.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Engagement-java/19?tool=ast&topic=Update+Terminology>Update Terminology</a>
        </td><td>Update the SDK's public API and examples to use "batches" instead of "files" for clarity, including changes in <code>Metadata</code> methods and example code.<details><summary>Modified files (4)</summary><ul><li>src/test/java/EngagementTest.java</li>
<li>readme.md</li>
<li>src/main/java/org/example/Main.java</li>
<li>src/main/java/optimove/sdk/engagement/Metadata.java</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Engagement-java/19?tool=ast&topic=Configure+SDK>Configure SDK</a>
        </td><td>Introduce new constructors for the <code>Engagement</code> class that accept a JSON string or an object to configure the SDK, leveraging the new <code>EngagementConfig</code> class for structured configuration, and pass the decryption key directly to <code>StorageSingleton</code> for secure Google Cloud Storage blob retrieval.<details><summary>Modified files (7)</summary><ul><li>src/test/java/EngagementTest.java</li>
<li>src/main/java/optimove/sdk/engagement/Engagement.java</li>
<li>readme.md</li>
<li>src/main/java/org/example/Main.java</li>
<li>pom.xml</li>
<li>src/main/java/optimove/sdk/engagement/EngagementConfig.java</li>
<li>src/main/java/optimove/sdk/engagement/StorageSingleton.java</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Engagement-java/19?tool=ast>(Baz)</a>.